### PR TITLE
Fix typo in javadoc

### DIFF
--- a/src/java/kodvel/core/route/RouteModel.java
+++ b/src/java/kodvel/core/route/RouteModel.java
@@ -10,7 +10,7 @@ import kodvel.core.controller.Controller;
 /**
  *  Store route information
  * 
- * Save method mane and Controller object.
+ * Save method name and Controller object.
  * It used for calling the method from controller object.
  * @author Md. Rezve Hasan
  * @since 0.0.1


### PR DESCRIPTION
Change "mane" to "name" in RouteModel class javadoc